### PR TITLE
Fix a NullPointerException bug when 'rsdev' property is null.

### DIFF
--- a/wrappers/java/src/main/java/org.librealsense/Native.java
+++ b/wrappers/java/src/main/java/org.librealsense/Native.java
@@ -22,7 +22,7 @@ public class Native {
 
     static {
         // check if development mode
-        boolean isRSDEV = System.getProperty("rsdev").equals("1");
+        boolean isRSDEV = System.getProperty("rsdev") != null && System.getProperty("rsdev").equals("1");
 
         // load native os specific libraries
         String os = System.getProperty("os.name").toLowerCase();


### PR DESCRIPTION
During static initialization when used, e.g., in Processing, the `rsdev` property
is not set, and therefore, is `null`, so a NullPointerException is thrown and hard
to debug. This minimal onliner fixes the issue. Traced back to this via
https://github.com/cansik/realsense-processing/issues/3.